### PR TITLE
verify publish message ttl before forwarding

### DIFF
--- a/lib/quasar.js
+++ b/lib/quasar.js
@@ -73,20 +73,14 @@ Quasar.prototype.publish = function(topic, data, options) {
 
   // Dispatch message to our closest neighbors
   async.each(neighbors, function(contact, done) {
-    // Construct our PUBLISH message
-    var message = kad.Message({
-      method: Quasar.PUBLISH_METHOD,
-      params: {
+    self._sendPublish(contact, {
         uuid: uuid.v4(),
         topic: topic,
         contents: data,
         publishers: [nodeID],
         ttl: Date.now() + self._options.ttl,
         contact: self._router._self
-      }
-    });
-
-    self._router._rpc.send(contact, message, done);
+      }, done);
   });
 };
 
@@ -190,6 +184,28 @@ Quasar.prototype._applyAttenuatedBloomFilterUpdate = function(atbf) {
 };
 
 /**
+ * Sends a PUBLISH message after verifying it has not expired
+ * @private
+ * @param {kad.Contact} contact
+ * @param {Object} params
+ * @param {Function} callback
+ */
+Quasar.prototype._sendPublish = function(contact, params, callback) {
+  var tnow = Date.now();
+
+  // check to make sure the message we are sending hasn't expired:
+  if(tnow > params.ttl) {
+    return callback(new Error('outgoing PUBLISH message has expired'));
+  }
+
+  // send the message:
+  this._router._rpc.send(contact, kad.Message({
+    params: merge(params, { contact: this._router._self }),
+    method: Quasar.PUBLISH_METHOD
+  }), callback);
+}
+
+/**
  * Inspects the message and routes it accordingly
  * @private
  * @param {Object} params
@@ -201,6 +217,7 @@ Quasar.prototype._handlePublish = function(params, callback) {
   var nodeID = this._router._self.nodeID;
   var limit = kad.constants.ALPHA;
   var neighbors = this._router.getNearestContacts(nodeID, limit, nodeID);
+  var tnow = Date.now();
 
   // Check to make sure that we have not already seen this message
   if (this._seen.get(params.uuid)) {
@@ -214,14 +231,14 @@ Quasar.prototype._handlePublish = function(params, callback) {
 
   // Add ourselves to the publishers (negative information)
   params.publishers.push(nodeID);
-  this._seen.set(params.uuid, Date.now());
+  this._seen.set(params.uuid, tnow);
 
   // If the message has expired, just drop it
-  if (Date.now() > params.ttl) {
+  if (tnow > params.ttl) {
     return callback(new Error('Message has expired'));
   }
 
-  var hasInvalidTtl = (params.ttl - Date.now()) > this._options.ttl;
+  var hasInvalidTtl = (params.ttl - tnow) > this._options.ttl;
 
   if (hasInvalidTtl) {
     return callback(new Error('Refusing to relay message due to invalid TTL'));
@@ -233,10 +250,7 @@ Quasar.prototype._handlePublish = function(params, callback) {
     this._groups[params.topic](params.contents, params.topic);
     // Pass the publication along to our neighbors
     return async.each(neighbors, function(contact, done) {
-      self._router._rpc.send(contact, kad.Message({
-        params: merge(params, { contact: self._router._self }),
-        method: Quasar.PUBLISH_METHOD
-      }), done);
+      self._sendPublish(contact, params, done);
     }, callback);
   }
 
@@ -259,10 +273,7 @@ Quasar.prototype._relayPublication = function(neighbors, params, callback) {
   function _relayToRandomNeighbor() {
     var randNeighbor = self._getRandomOverlayNeighbor(nodeID, params.topic);
 
-    self._router._rpc.send(randNeighbor, kad.Message({
-      params: merge(params, { contact: self._router._self }),
-      method: Quasar.PUBLISH_METHOD
-    }), function() {});
+    self._sendPublish(randNeighbor, params, function() {});
   }
 
   // Ack the original sender, so they do not drop us from routing table
@@ -276,11 +287,7 @@ Quasar.prototype._relayPublication = function(neighbors, params, callback) {
   async.filter(neighbors, function(contact, done) {
 
     function _relayMessage() {
-      var msg = kad.Message({
-        params: merge(params, { contact: self._router._self }),
-        method: Quasar.PUBLISH_METHOD
-      });
-      return self._router._rpc.send(contact, msg, function onResponse() {
+      return self._sendPublish(contact, params, function onResponse() {
         done(true);
       });
     }

--- a/lib/quasar.js
+++ b/lib/quasar.js
@@ -203,7 +203,7 @@ Quasar.prototype._sendPublish = function(contact, params, callback) {
     params: merge(params, { contact: this._router._self }),
     method: Quasar.PUBLISH_METHOD
   }), callback);
-}
+};
 
 /**
  * Inspects the message and routes it accordingly


### PR DESCRIPTION
Prevents #9 by checking the ttl on every outgoing PUBLISH message for expiration. Also cleans up repetitive Date.now() calls (expensive).